### PR TITLE
Remove irrelevant references from PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,5 @@
 Fixes issue(s) # .
 
-[![CircleCI](https://circleci.com/gh/18F/nsf-sbir/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/nsf-sbir/tree/BRANCH_NAME)
-
-[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/nsf-sbir/BRANCH_NAME/)
-
-[Preview README for this branch](https://github.com/18F/nsf-sbir/blob/BRANCH_NAME/README.md)
-
 Changes proposed in this pull request:
 -
 -


### PR DESCRIPTION
We were referencing nsf-sbir, Federalist, and Circle; none of which are used in this project.