### PR TITLE
Add a "cronish" worker to call cron every 15m.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,7 +25,7 @@ install_drupal() {
     drupal --root=$HOME/web config:override system.site uuid $UUID
 }
 
-if [ "${CF_INSTANCE_INDEX:-''}" == "0" ] && [ "${APP_NAME}" == "web" ]; then
+if [ "${CF_INSTANCE_INDEX:-''}" == "0" ] && [ "${APP_NAME}" == "nsf-demo" ]; then
   drupal --root=$HOME/web list | grep database > /dev/null || install_drupal
   # Sync configs from code
   drupal --root=$HOME/web config:import --directory $HOME/web/sites/default/config

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,8 +8,8 @@ install_drupal() {
     ROOT_USER_NAME=$(echo $SECRETS | jq -r '.ROOT_USER_NAME')
     ROOT_USER_PASS=$(echo $SECRETS | jq -r '.ROOT_USER_PASS')
 
-    : "${ACCOUNT_NAME:?Need and root user name for Drupal}"
-    : "${ACCOUNT_PASS:?Need and root user pass for Drupal}"
+    : "${ROOT_USER_NAME:?Need and root user name for Drupal}"
+    : "${ROOT_USER_PASS:?Need and root user pass for Drupal}"
 
     drupal site:install \
         --root=$HOME/web \

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 SECRETS=$(echo $VCAP_SERVICES | jq -r '.["user-provided"][] | select(.name == "secrets") | .credentials')
+APP_NAME=$(echo $VCAP_APPLICATION | jq -r '.name')
 
 install_drupal() {
     ROOT_USER_NAME=$(echo $SECRETS | jq -r '.ROOT_USER_NAME')
@@ -24,7 +25,7 @@ install_drupal() {
     drupal --root=$HOME/web config:override system.site uuid $UUID
 }
 
-if [ "${CF_INSTANCE_INDEX:-''}" == "0" ]; then
+if [ "${CF_INSTANCE_INDEX:-''}" == "0" ] && [ "${APP_NAME}" == "web" ]; then
   drupal --root=$HOME/web list | grep database > /dev/null || install_drupal
   # Sync configs from code
   drupal --root=$HOME/web config:import --directory $HOME/web/sites/default/config

--- a/cronish.sh
+++ b/cronish.sh
@@ -1,0 +1,8 @@
+#!/bin/bash 
+set -euo pipefail
+
+while true
+do
+  drupal --root=$HOME/web cron:execute
+  sleep 15m
+done

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,24 +1,27 @@
 ---
-buildpack: php_buildpack
-disk_quota: 512M
-timeout: 180
-services:
-  - database # cf create-service aws-rds medium-mysql database
-  - secrets  # cf create-user-provided-service secrets -p '{
-             # "BRIGHTCOVE_ACCOUNT": ...
-             # "BRIGHTCOVE_CLIENT": ...
-             # "BRIGHTCOVE_SECRET": ...
-             # "HASH_SALT": ...
-             # "ROOT_USER_NAME": ...,
-             # "ROOT_USER_PASS": ...,
-             # }'
-  - storage  # cf create-service s3 basic storage
+default_config: &defaults
+  buildpack: php_buildpack
+  disk_quota: 512M
+  timeout: 180
+  services:
+    - database # cf create-service aws-rds medium-mysql database
+    - secrets  # cf create-user-provided-service secrets -p '{
+               # "BRIGHTCOVE_ACCOUNT": ...
+               # "BRIGHTCOVE_CLIENT": ...
+               # "BRIGHTCOVE_SECRET": ...
+               # "HASH_SALT": ...
+               # "ROOT_USER_NAME": ...,
+               # "ROOT_USER_PASS": ...,
+               # }'
+    - storage  # cf create-service s3 basic storage
 
 applications:
 - name: nsf-demo
+  <<: *defaults
   memory: 256M
   instances: 1
 - name: cronish
+  <<: *defaults
   no-route: true
   command: ./cronish.sh
   health-check-type: process

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,19 +1,24 @@
 ---
+buildpack: php_buildpack
+memory: 512M
+disk_quota: 512M
+timeout: 180
+services:
+  - database # cf create-service aws-rds medium-mysql database
+  - secrets  # cf create-user-provided-service secrets -p '{
+             # "BRIGHTCOVE_ACCOUNT": ...
+             # "BRIGHTCOVE_CLIENT": ...
+             # "BRIGHTCOVE_SECRET": ...
+             # "HASH_SALT": ...
+             # "ROOT_USER_NAME": ...,
+             # "ROOT_USER_PASS": ...,
+             # }'
+  - storage  # cf create-service s3 basic storage
+
 applications:
 - name: nsf-demo
-  buildpack: php_buildpack
   instances: 1
-  memory: 512M
-  disk_quota: 512M
-  timeout: 180
-  services:
-    - database # cf create-service aws-rds medium-mysql database
-    - secrets  # cf create-user-provided-service secrets -p '{
-               # "BRIGHTCOVE_ACCOUNT": ...
-               # "BRIGHTCOVE_CLIENT": ...
-               # "BRIGHTCOVE_SECRET": ...
-               # "HASH_SALT": ...
-               # "ROOT_USER_NAME": ...,
-               # "ROOT_USER_PASS": ...,
-               # }'
-    - storage  # cf create-service s3 basic storage
+- name: cronish
+  no-route: true
+  command: ./cronish.sh
+  health-check-type: process

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,5 @@
 ---
 buildpack: php_buildpack
-memory: 512M
 disk_quota: 512M
 timeout: 180
 services:
@@ -17,8 +16,10 @@ services:
 
 applications:
 - name: nsf-demo
+  memory: 256M
   instances: 1
 - name: cronish
   no-route: true
   command: ./cronish.sh
   health-check-type: process
+  memory: 128M


### PR DESCRIPTION
Cloud.gov doesn't offer time-based task execution yet; luckily, it's very easy
to imitate with a loop in bash. This'll execute the `cron:execute` command
roughly every 15m (there's a slight skew due to amount of time processing that
command).

It also moves app configuration up a level in the manifest, as most of these
configs are shared and reduces our apps' memory resources.