### PR TITLE
Add production manifest; rename web app.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,7 +25,7 @@ install_drupal() {
     drupal --root=$HOME/web config:override system.site uuid $UUID
 }
 
-if [ "${CF_INSTANCE_INDEX:-''}" == "0" ] && [ "${APP_NAME}" == "nsf-demo" ]; then
+if [ "${CF_INSTANCE_INDEX:-''}" == "0" ] && [ "${APP_NAME}" == "web" ]; then
   drupal --root=$HOME/web list | grep database > /dev/null || install_drupal
   # Sync configs from code
   drupal --root=$HOME/web config:import --directory $HOME/web/sites/default/config

--- a/manifest-prod.yml
+++ b/manifest-prod.yml
@@ -21,7 +21,8 @@ applications:
   memory: 256M
   instances: 1
   routes:
-    - route: nsf-demo.app.cloud.gov
+    - route: beta.nsf.gov
+    - route: nsf-beta.app.cloud.gov
 - name: cronish
   <<: *defaults
   no-route: true


### PR DESCRIPTION
This prepares us for the production environment by creating a new,
production-specific manifest file. It's a duplicate of manifest.yml, changing
only the "domains" key. Cloud Foundry's manifest inheritance is deprecated,
but they haven't implemented their variable substitution strategy yet, so this
duplication seems like the best path forward.

This renames the application to "web" so there isn't an "nsf-demo" app in the
"prod" space.

To deploy to prod, we'll run:
```
cf target -o nsf-prototyping -s prod
cf push -f manifest-prod.yml
```