### PR TITLE
Fix initial install error.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,8 +7,8 @@ install_drupal() {
     ROOT_USER_NAME=$(echo $SECRETS | jq -r '.ROOT_USER_NAME')
     ROOT_USER_PASS=$(echo $SECRETS | jq -r '.ROOT_USER_PASS')
 
-    : "${ACCOUNT_NAME:?Need and root user name for Drupal}"
-    : "${ACCOUNT_PASS:?Need and root user pass for Drupal}"
+    : "${ROOT_USER_NAME:?Need and root user name for Drupal}"
+    : "${ROOT_USER_PASS:?Need and root user pass for Drupal}"
 
     drupal site:install \
         --root=$HOME/web \


### PR DESCRIPTION
When running the prod install for the first time, I ran into an error around
a missing variable. Looks like I forgot I missed a few instances when
switching between variable names. This resolves.