### PR TITLE
Tell Drupal our config location; fix htaccess bug

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -29,7 +29,7 @@ install_drupal() {
 if [ "${CF_INSTANCE_INDEX:-''}" == "0" ] && [ "${APP_NAME}" == "web" ]; then
   drupal --root=$APP_ROOT/web list | grep database > /dev/null || install_drupal
   # Sync configs from code
-  drupal --root=$APP_ROOT/web config:import --directory $APP_ROOT/web/sites/default/config
+  drupal --root=$APP_ROOT/web config:import
 
   # Secrets
   CRON_KEY=$(openssl rand -base64 32)  # Not used, so we set it to a random val

--- a/web/sites/default/config/.htaccess
+++ b/web/sites/default/config/.htaccess
@@ -6,7 +6,8 @@
 # Deny all requests from Apache 2.0-2.2.
 <IfModule !mod_authz_core.c>
   Deny from all
-</IfModule># Turn off all options we don't need.
+</IfModule>
+# Turn off all options we don't need.
 Options None
 Options +FollowSymLinks
 

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -771,7 +771,7 @@ $settings['file_scan_ignore_directories'] = [
  */
 $settings['entity_update_batch_size'] = 50;
 
-$config_directories['sync'] = '../config/sync';
+$config_directories['sync'] = './sites/default/config/';
 $settings['install_profile'] = 'standard';
 include $app_root . '/' . $site_path . '/settings.cf.php';
 


### PR DESCRIPTION
We can configure Drupal to import/export configs to a directory, rather than needing to spell it out when invoking `drush` or `drupal`. This also resolves a 500 error when attempting to access the configs (it now correctly returns a 403).

It might make sense to instead move the configs out of the `web` directory and into a peer `config/sync` (the default) dir. The configs contain sensitive info -- I'm a bit concerned that an htaccess file isn't enough to hide them.