### PR TITLE
Set logs to store indefinitely.

### DIFF
--- a/web/sites/default/config/dblog.settings.yml
+++ b/web/sites/default/config/dblog.settings.yml
@@ -1,3 +1,3 @@
-row_limit: 1000
+row_limit: 0
 _core:
   default_config_hash: e883aGsrt1wFrsydlYU584PZONCSfRy0DtkZ9KzHb58


### PR DESCRIPTION
As part of our SSR, we're claiming to store logs for at least a year. We've
also noted that the logs are stored (for now) in the database.

As @fureigh pointed out, this is a frequent performance bottleneck for Drupal
sites. Unfortunately, there's not enough runway to create a longer term
solution (like writing to syslog) as we know from our users that they want to
see subsets of the logs within the application. We're kicking that can down
the road a bit.