### PR TITLE
Update site name and homepage

### DIFF
--- a/web/sites/default/config/system.site.yml
+++ b/web/sites/default/config/system.site.yml
@@ -5,7 +5,7 @@ slogan: ''
 page:
   403: ''
   404: ''
-  front: /node
+  front: /blog
 admin_compact_mode: false
 weight_select_max: 100
 langcode: en

--- a/web/sites/default/config/system.site.yml
+++ b/web/sites/default/config/system.site.yml
@@ -1,5 +1,5 @@
 uuid: f047fa5b-89c8-4f6b-80de-7ea36c91cf55
-name: 'nsf demo'
+name: beta.nsf.gov
 mail: rhys.fureigh@gsa.gov
 slogan: ''
 page:


### PR DESCRIPTION
This pull request does the following:
- Changes the site name to `beta.nsf.gov`
- Changes the homepage from a placeholder blank page to the social media page