### PR TITLE
Enable S3 storage for our image fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,32 @@ Within the `bin` directory, there are a handful of helpful scripts to make
 running `drupal`, `drush`, etc. within the context of our Dockerized app
 easier. As noted above, they are written with bash in mind, but should be easy
 to port to other environments.
+
+### File storage
+
+We've configured our file fields to store content in S3; in this way, they
+persist between app restarts and deploys. Unfortunately, those configurations
+are therefore also present locally, which can lead to unexpected results (we
+*don't* include sensitive bucket credentials, so we'll see "The file could not
+be uploaded."). If needing to work with  file uploads locally, modify the
+relevant field's "storage" away from "Flysystem: S3" to "Public files" (which
+means the local disk). This can be configured in the Drupal administration
+interface, or by editing the configuration files in
+`web/sites/default/config`. Notably, all instances of
+
+```yaml
+uri_scheme: s3
+```
+
+should become
+
+```yaml
+uri_scheme: public
+```
+
+and Docker restarted.
+
+Alternatively, if testing S3 integration, it's possible to configure Docker to
+use a real S3 bucket by editing `docker-compose.yml`. That file holds a series
+of values under the "s3" key which will need to be modified with your access
+credentials.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,15 @@ services:
               "username": "root"
             }
           }],
+          "s3": [{
+            "name": "storage",
+            "credentials": {
+             "access_key_id": "SECRET",
+             "bucket": "SECRET",
+             "region": "SECRET",
+             "secret_access_key": "SECRET"
+            }
+          }],
           "user-provided": [{
             "name": "secrets",
             "credentials": {

--- a/web/sites/default/config/core.extension.yml
+++ b/web/sites/default/config/core.extension.yml
@@ -33,6 +33,8 @@ module:
   field_ui: 0
   file: 0
   filter: 0
+  flysystem: 0
+  flysystem_s3: 0
   help: 0
   history: 0
   image: 0

--- a/web/sites/default/config/field.storage.node.field_featured_image.yml
+++ b/web/sites/default/config/field.storage.node.field_featured_image.yml
@@ -11,7 +11,7 @@ field_name: field_featured_image
 entity_type: node
 type: image
 settings:
-  uri_scheme: public
+  uri_scheme: s3
   default_image:
     uuid: ''
     alt: ''

--- a/web/sites/default/config/field.storage.user.user_picture.yml
+++ b/web/sites/default/config/field.storage.user.user_picture.yml
@@ -13,9 +13,9 @@ field_name: user_picture
 entity_type: user
 type: image
 settings:
-  uri_scheme: public
+  uri_scheme: s3
   default_image:
-    uuid: null
+    uuid: ''
     alt: ''
     title: ''
     width: null


### PR DESCRIPTION
We had been including the flysystem dependencies but hadn't configured its
use. This sets our two image fields to store their content in s3 (as the local
file system is volatile and may disappear between app restarts).

It also updates the README and docker-compose file so everything continues to _run_ locally (though see the note in the README around actually uploading files).