### PR TITLE
Remove account menu, including 'log in' link

### DIFF
--- a/web/sites/default/config/block.block.nsf_account_menu.yml
+++ b/web/sites/default/config/block.block.nsf_account_menu.yml
@@ -1,6 +1,6 @@
 uuid: 7aae90ad-403c-4150-a032-cf5fdfc15d7d
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - system.menu.account


### PR DESCRIPTION
No one's meant to log in, currently, so let's not present the link.

https://github.com/18F/nsf/issues/161
https://github.com/18F/nsf/issues/162

Changes proposed in this pull request:
 * Remove the `account menu` block from the header.

Technical notes:
 * Here I've disabled the block, not removed it. This was for ease of re-adding it in the future, but another option is to entirely remove it; a future developer would still be able to restore it by reverting the commit(s) from this PR.
 * In a separate issue, let's programmatically prevent people from being able to log in. (Remove the `/user/login` route, etc.)