### PR TITLE
Add standard government banner from USWDS

### DIFF
--- a/web/sites/default/config/nsf.settings.yml
+++ b/web/sites/default/config/nsf.settings.yml
@@ -12,7 +12,7 @@ favicon:
 uswds_header_style: basic
 uswds_header_mega: 0
 uswds_search: 0
-uswds_government_banner: 0
+uswds_government_banner: 1
 uswds_footer_style: slim
 uswds_footer_agency: 0
 uswds_footer_agency_name: ''


### PR DESCRIPTION
This pull request adds a banner that reads "An official website of the United States government. Here's how you know", with a link to more information.

Related issues:
* Part of https://github.com/18F/nsf/issues/162.
* A step toward https://github.com/18F/nsf/issues/193. Next step: update the content to be beta-specific.

Changes proposed in this pull request:
* Add the standard "An official website of the United States government" banner