### PR TITLE
Uninstall masquerade.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -31,7 +31,7 @@ if [ "${CF_INSTANCE_INDEX:-''}" == "0" ] && [ "${APP_NAME}" == "web" ]; then
   # Mild data migration: fully delete database entries related to these
   # modules. These plugins (and the dependencies) can be removed once they've
   # been uninstalled in all environments
-  drupal --root=$APP_ROOT/web module:uninstall workflow
+  drupal --root=$APP_ROOT/web module:uninstall masquerade workflow
   drupal --root=$APP_ROOT/web theme:uninstall bootstrap
 
   # Sync configs from code

--- a/web/sites/default/config/core.extension.yml
+++ b/web/sites/default/config/core.extension.yml
@@ -41,7 +41,6 @@ module:
   inline_entity_form: 0
   inline_form_errors: 0
   link: 0
-  masquerade: 0
   media_entity: 0
   media_entity_brightcove: 0
   menu_ui: 0


### PR DESCRIPTION
Per the experience we had when uninstalling workflow, we know we need to run
the `module:uninstall` command and _keep_ the PHP code until the modules are
completely removed from all environments. This is the first step of that
process.

This manifests the changes I recommended in #195 