### PR TITLE
Unbind beta.nsf.gov.

### DIFF
--- a/manifest-prod.yml
+++ b/manifest-prod.yml
@@ -21,8 +21,8 @@ applications:
   memory: 256M
   instances: 1
   routes:
-    - route: beta.nsf.gov
     - route: nsf-beta.app.cloud.gov
+#   - route: beta.nsf.gov
 - name: cronish
   <<: *defaults
   no-route: true


### PR DESCRIPTION
Per conversation with Matt and Theresa, we don't want beta to be associated
with NSF until there's a full time team.