### PR TITLE
Execute all cron tasks every 15m.

### DIFF
--- a/cronish.sh
+++ b/cronish.sh
@@ -3,6 +3,6 @@ set -euo pipefail
 
 while true
 do
-  drupal --root=$HOME/web cron:execute
+  drupal --root=$HOME/web cron:execute all
   sleep 15m
 done


### PR DESCRIPTION
Unfortunately, `cron:execute` claims everything went well, but doesn't
actually execute any cron tasks. By adding the "all" parameter, we solve his
problem.

Fixes issue(s) #203 .