### PR TITLE
Add mechanism for initial content

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ use a real S3 bucket by editing `docker-compose.yml`. That file holds a series
 of values under the "s3" key which will need to be modified with your access
 credentials.
 
-### Workflow
+### Configuration workflow
 
 Making configuration changes to the application comes in roughly eight small steps:
 1. get the latest code
@@ -185,6 +185,45 @@ git push origin 333-add-the-whatsit
 ```
 
 And request a review in GitHub's interface.
+
+### Content workflow
+
+We'll also treat some pieces of content similar to configuration -- we want to
+deploy it with the code base rather than add/modify it in individual
+environments. The steps for this are very similar to the Config workflow:
+
+1. get the latest code
+1. create a feature branch
+1. add/edit content in the Drupal admin
+1. export the content
+1. commit the changes
+1. push your branch to GitHub
+1. create a pull request to be reviewed
+
+The first two steps are identical to the Config workflow, so we'll skip to the
+third. Start the application:
+
+```
+docker-compose up
+```
+
+Then [http://localhost:8080/user/login](log in) as root (password: root).
+Create or edit content (e.g. Aggregator feeds, pages, etc.) through the Drupal
+admin.
+
+Next, we'll export this content via Drush:
+
+```sh
+# Export all entities of a particular type
+bin/drush default-content-deploy:export [type-of-entity e.g. aggregator_feed]
+# Export individual entities
+bin/drush default-content-deploy:export [type-of-entity] --entity-id=[ids e.g. 1,3,7]
+```
+
+Then, we'll review all of the changes and commit those that are relevant.
+Notably, we're expecting new or modified files in `web/sites/default/content`.
+After committing, we'll sent to GitHub and create a pull request as with
+config changes.
 
 ### Removing dependencies
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -47,6 +47,9 @@ if [ "${CF_INSTANCE_INDEX:-''}" == "0" ] && [ "${APP_NAME}" == "web" ]; then
   drupal --root=$APP_ROOT/web config:override brightcove.brightcove_api_client.nsf_brightcove client_id $BRIGHTCOVE_CLIENT > /dev/null
   drupal --root=$APP_ROOT/web config:override brightcove.brightcove_api_client.nsf_brightcove secret_key $BRIGHTCOVE_SECRET > /dev/null
 
+  # Import initial content
+  drush --root=$APP_ROOT/web default-content-deploy:import
+
   # Clear the cache
   drupal --root=$APP_ROOT/web cache:rebuild --no-interaction
 fi

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "drupal/console": "^1.0.2",
         "drupal/core": "~8.4",
         "drupal/ctools": "^3.0",
+        "drupal/default_content_deploy": "^1.0@alpha",
         "drupal/devel": "^1.2",
         "drupal/diff": "^1.0@RC",
         "drupal/embed": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e8f381c09766b5590557d88c592e396",
+    "content-hash": "d46503590f4ef8832e6de4d4641e9e4f",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2326,6 +2326,139 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/ctools",
                 "issues": "https://www.drupal.org/project/issues/ctools"
+            }
+        },
+        {
+            "name": "drupal/default_content",
+            "version": "1.0.0-alpha7",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/default_content",
+                "reference": "8.x-1.0-alpha7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/default_content-8.x-1.0-alpha7.zip",
+                "reference": "8.x-1.0-alpha7",
+                "shasum": "4f1b49cdad6d74ef879f4700caaa11703ba85ad7"
+            },
+            "require": {
+                "drupal/core": "~8.3"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.0-alpha7",
+                    "datestamp": "1508448545",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Berdir",
+                    "homepage": "https://www.drupal.org/user/214652"
+                },
+                {
+                    "name": "Sam152",
+                    "homepage": "https://www.drupal.org/user/1485048"
+                },
+                {
+                    "name": "andypost",
+                    "homepage": "https://www.drupal.org/user/118908"
+                },
+                {
+                    "name": "benjy",
+                    "homepage": "https://www.drupal.org/user/1852732"
+                },
+                {
+                    "name": "dawehner",
+                    "homepage": "https://www.drupal.org/user/99340"
+                },
+                {
+                    "name": "jibran",
+                    "homepage": "https://www.drupal.org/user/1198144"
+                },
+                {
+                    "name": "larowlan",
+                    "homepage": "https://www.drupal.org/user/395439"
+                }
+            ],
+            "description": "Imports default content when a module is enabled",
+            "homepage": "https://www.drupal.org/project/default_content",
+            "support": {
+                "source": "http://cgit.drupalcode.org/default_content"
+            }
+        },
+        {
+            "name": "drupal/default_content_deploy",
+            "version": "1.0.0-alpha5",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/default_content_deploy",
+                "reference": "8.x-1.0-alpha5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/default_content_deploy-8.x-1.0-alpha5.zip",
+                "reference": "8.x-1.0-alpha5",
+                "shasum": "945475c5a46dafd921183cc7c7f0e9bcb0e1c1e2"
+            },
+            "require": {
+                "drupal/core": "~8.0",
+                "drupal/default_content": "1.0-alpha7",
+                "php": ">=5.6.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.0-alpha5",
+                    "datestamp": "1518545580",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Martin Klíma",
+                    "homepage": "https://www.drupal.org/user/340058",
+                    "email": "author@example.com"
+                },
+                {
+                    "name": "Jakub Hnilička",
+                    "homepage": "https://www.drupal.org/user/2784335"
+                },
+                {
+                    "name": "Radoslav Terezka"
+                }
+            ],
+            "description": "Drupal 8 module for deploying content in *.json files. Sponsored by: HBF s.r.o., http://hbf.sk, https://drupal.org/hbf",
+            "homepage": "https://www.drupal.org/project/default_content_deploy",
+            "support": {
+                "source": "http://cgit.drupalcode.org/default_content_deploy"
             }
         },
         {
@@ -7211,6 +7344,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "drupal/default_content_deploy": 15,
         "drupal/diff": 5,
         "drupal/entity_embed": 10,
         "drupal/flysystem_s3": 15,

--- a/web/sites/default/config/core.extension.yml
+++ b/web/sites/default/config/core.extension.yml
@@ -18,6 +18,8 @@ module:
   ctools: 0
   datetime: 0
   dblog: 0
+  default_content: 0
+  default_content_deploy: 0
   devel: 0
   devel_generate: 0
   diff: 0
@@ -35,6 +37,7 @@ module:
   filter: 0
   flysystem: 0
   flysystem_s3: 0
+  hal: 0
   help: 0
   history: 0
   image: 0
@@ -55,6 +58,7 @@ module:
   scheduler: 0
   scheduler_rules_integration: 0
   search: 0
+  serialization: 0
   shortcut: 0
   system: 0
   taxonomy: 0

--- a/web/sites/default/config/hal.settings.yml
+++ b/web/sites/default/config/hal.settings.yml
@@ -1,0 +1,4 @@
+link_domain: null
+bc_file_uri_as_url_normalizer: false
+_core:
+  default_config_hash: swYtdod4psGvRvRY6OTGagGJPAuknS7WMgn1089yjL0

--- a/web/sites/default/config/serialization.settings.yml
+++ b/web/sites/default/config/serialization.settings.yml
@@ -1,0 +1,4 @@
+bc_primitives_as_strings: false
+bc_timestamp_normalizer_unix: false
+_core:
+  default_config_hash: 6A1rmsmNf4SJrwCEt_aZyO_kPYuFnIOPC2n5lJiIftA

--- a/web/sites/default/content/.htaccess
+++ b/web/sites/default/content/.htaccess
@@ -1,0 +1,24 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+# Turn off all options we don't need.
+Options None
+Options +FollowSymLinks
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php5.c>
+  php_flag engine off
+</IfModule>

--- a/web/sites/default/content/aggregator_feed/3f9d422e-3eb3-406c-b3e3-c4618832738e.json
+++ b/web/sites/default/content/aggregator_feed/3f9d422e-3eb3-406c-b3e3-c4618832738e.json
@@ -1,0 +1,52 @@
+{
+    "_links": {
+        "self": {
+            "href": "http:\/\/default\/aggregator\/sources\/2?_format=hal_json"
+        },
+        "type": {
+            "href": "http:\/\/drupal.org\/rest\/type\/aggregator_feed\/aggregator_feed"
+        }
+    },
+    "fid": [
+        {
+            "value": 2
+        }
+    ],
+    "uuid": [
+        {
+            "value": "3f9d422e-3eb3-406c-b3e3-c4618832738e"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "title": [
+        {
+            "value": "Notes from the Field"
+        }
+    ],
+    "url": [
+        {
+            "value": "http:\/\/nsfdirectorfieldnotes.tumblr.com\/rss"
+        }
+    ],
+    "refresh": [
+        {
+            "value": 3600
+        }
+    ],
+    "checked": [
+        {
+            "value": "1970-01-01T00:00:00+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "queued": [
+        {
+            "value": "1970-01-01T00:00:00+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ]
+}

--- a/web/sites/default/content/aggregator_feed/c79e1596-ba1f-48be-b953-94815ad66d7e.json
+++ b/web/sites/default/content/aggregator_feed/c79e1596-ba1f-48be-b953-94815ad66d7e.json
@@ -1,0 +1,67 @@
+{
+    "_links": {
+        "self": {
+            "href": "http:\/\/default\/aggregator\/sources\/1?_format=hal_json"
+        },
+        "type": {
+            "href": "http:\/\/drupal.org\/rest\/type\/aggregator_feed\/aggregator_feed"
+        }
+    },
+    "fid": [
+        {
+            "value": 1
+        }
+    ],
+    "uuid": [
+        {
+            "value": "c79e1596-ba1f-48be-b953-94815ad66d7e"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "title": [
+        {
+            "value": "National Science Foundation"
+        }
+    ],
+    "url": [
+        {
+            "value": "http:\/\/nationalsciencefoundation.tumblr.com\/rss"
+        }
+    ],
+    "refresh": [
+        {
+            "value": 3600
+        }
+    ],
+    "checked": [
+        {
+            "value": "2018-03-30T14:24:49+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "queued": [
+        {
+            "value": "1970-01-01T00:00:00+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "link": [
+        {
+            "value": "http:\/\/nationalsciencefoundation.tumblr.com\/"
+        }
+    ],
+    "description": [
+        {
+            "value": "The National Science Foundation (NSF) is an independent federal agency created by Congress in 1950. We fund a significant proportion of federally supported basic research. Follow our Tumblr to learn about projects, people and infrastructure in every\u2026"
+        }
+    ],
+    "hash": [
+        {
+            "value": "83e424da2f3877b827bcb8185732f278f6e234bb61eba0dd3fa47fe985357201"
+        }
+    ]
+}

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -772,6 +772,7 @@ $settings['file_scan_ignore_directories'] = [
 $settings['entity_update_batch_size'] = 50;
 
 $config_directories['sync'] = './sites/default/config/';
+$config['content_directory'] = './sites/default/content';
 $settings['install_profile'] = 'standard';
 include $app_root . '/' . $site_path . '/settings.cf.php';
 


### PR DESCRIPTION
Building off the Drush PR (#209), this adds the [Default Content Deploy](https://www.drupal.org/project/default_content_deploy) module and commits our initial aggregator feeds to code.