### PR TITLE
Remove contact form permission from anon users.

### DIFF
--- a/web/sites/default/config/user.role.anonymous.yml
+++ b/web/sites/default/config/user.role.anonymous.yml
@@ -12,6 +12,5 @@ permissions:
   - 'access comments'
   - 'access content'
   - 'access news feeds'
-  - 'access site-wide contact form'
   - 'use text format restricted_html'
   - 'view published brightcove videos'


### PR DESCRIPTION
Per #205, we don't want anonymous users to be able to submit to the contact
from. We *may* want internal users to have access, in the future, however.

Fixes #205 