### PR TITLE
Remove `more` link and pager

### DIFF
--- a/web/sites/default/config/views.view.nsf_blog.yml
+++ b/web/sites/default/config/views.view.nsf_blog.yml
@@ -44,23 +44,10 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       pager:
-        type: mini
+        type: some
         options:
           items_per_page: 10
           offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
       style:
         type: grid
         options:
@@ -171,7 +158,6 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - url.query_args
       tags: {  }
   block_1:
     display_plugin: block
@@ -379,7 +365,7 @@ display:
         groups:
           1: AND
       enabled: true
-      use_more: true
+      use_more: false
       use_more_always: false
       use_more_text: more
     cache_metadata:
@@ -387,5 +373,4 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - url.query_args
       tags: {  }


### PR DESCRIPTION
Cleaning up the appearance of the aggregated Tumblr posts.

Prompted by working on issue #220.