### PR TITLE
Include videos in imported Tumblr posts

### DIFF
--- a/web/sites/default/config/aggregator.settings.yml
+++ b/web/sites/default/config/aggregator.settings.yml
@@ -3,7 +3,7 @@ parser: aggregator
 processors:
   - aggregator
 items:
-  allowed_html: '<a> <b> <br> <dd> <dl> <dt> <em> <i> <li> <ol> <p> <strong> <u> <ul> <img> <video> <figure>'
+  allowed_html: '<a> <b> <br> <dd> <dl> <dt> <em> <i> <li> <ol> <p> <strong> <u> <ul> <img> <video> <figure> <iframe>'
   teaser_length: 400
   expire: 0
 source:


### PR DESCRIPTION
Tumblr's RSS feeds use iframes for presenting YouTube videos, so this pull request adds them to the list of allowed tags.

(Please note that this change doesn't modify feed items that have already been imported. To have this change affect already-posted feed items, the items must be deleted and re-'updated'. Fortunately, our deployment process has the same effect.)

Fixes issue #219.