### PR TITLE
Update composer.json to indicate Drupal 8.5+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "drupal/bootstrap": "^3.11",
         "drupal/brightcove": "^1.3",
         "drupal/console": "^1.0.2",
-        "drupal/core": "~8.4",
+        "drupal/core": "~8.5",
         "drupal/ctools": "^3.0",
         "drupal/default_content_deploy": "^1.0@alpha",
         "drupal/devel": "^1.2",


### PR DESCRIPTION
#225 updated Drupal to the most recent version, following the announcement of a security vulnerability. This PR simply updates composer.json to indicate more clearly (to the human eye)
that we're running Drupal 8.5.* or better.